### PR TITLE
Updated for Bedrock 1.20.40

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,12 @@ if (CMAKE_VERSION VERSION_LESS 3.0.0)
 else()
   set(CMAKE_CXX_STANDARD 11)
 endif()
-set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+#BDS is built with libc++ instead of libstdc++ since 1.20.40
+set(CMAKE_CXX_COMPILER "clang++")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
 
 find_package(ModLoader REQUIRED)
 

--- a/log_forwarder.cpp
+++ b/log_forwarder.cpp
@@ -13,7 +13,7 @@ public:
   static const char* _areaFilterString(LogAreaID);
 };
 
-TStaticHook(void, _ZN10BedrockLog6log_vaENS_11LogCategoryESt6bitsetILm3EENS_7LogRuleE9LogAreaIDjPKciS6_P13__va_list_tag,
+TStaticHook(void, _ZN10BedrockLog6log_vaENS_11LogCategoryENSt3__16bitsetILm3EEENS_7LogRuleE9LogAreaIDjPKciS7_P13__va_list_tag,
             BedrockLog, unsigned int category, std::bitset<3> set, int rule, LogAreaID area, unsigned int level,
             char const* tag, int tid, char const* format, va_list args) {
   Log::LogLevel ourLevel = MODLOADER_LOG_ERROR;

--- a/version_name.cpp
+++ b/version_name.cpp
@@ -7,7 +7,7 @@
 
 using namespace modloader;
 
-THook(std::string, _ZN6Common22getServerVersionStringB5cxx11Ev) {
+THook(std::string, _ZN6Common22getServerVersionStringEv) {
   std::string ret = original();
   ret += " modded (ModLoader ";
   ret += ModLoader::getVersion();


### PR DESCRIPTION
The binary is now linked to libc++ instead of libstdc++. Switching to clang++ probably not strictly necessary, but solves a bunch of issues with stuff like linking to constructors too.

The modloader itself will require an update to deal with this too.